### PR TITLE
Makefile: mark side-effect-only targets as phony

### DIFF
--- a/microservices-rest/Makefile
+++ b/microservices-rest/Makefile
@@ -1,3 +1,5 @@
+.PHONY: web router repository nuke_deployments nuke_services nuke_pods deploy
+
 all: web router repository
 
 web: web_image


### PR DESCRIPTION
This way, you won’t need to manually copy&paste commands like in the workshop just now :)